### PR TITLE
Fixing openapi schema to avoid errors and warnings

### DIFF
--- a/website/static/downloads/swagger.yaml
+++ b/website/static/downloads/swagger.yaml
@@ -618,7 +618,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  ID:
+                  Result:
                     $ref: '#/components/schemas/cid'
         '400': 
           $ref: '#/components/responses/errorResp'
@@ -662,7 +662,11 @@ paths:
               schema:
                 type: object
                 properties:
-                  ID:
+                  ScId:
+                    description: SuperContract ID is [Cid](https://github.com/multiformats/cid) (version 1) - special content identifier.
+                    type: string
+                    example: baegqajaiaqjcak6kujbwwdsx3ytcv5wvyrf7fwcij7yvb527laruzjgwch5jxqlm
+                  TxHash:
                     $ref: '#/components/schemas/cid'
         '400': 
           $ref: '#/components/responses/errorResp'
@@ -691,7 +695,7 @@ paths:
     post:
       tags:
       - SuperContract
-      summary: Get SuperContract
+      summary: Get SuperContracts IDs
       description: Get all SuperContract on a drive.
       operationId: lsSC
       parameters:
@@ -896,7 +900,9 @@ components:
             /:
               $ref: '#/components/schemas/cid'
     pubKey:
-      $ref: '#/components/schemas/pubKey'
+      type: string
+      example: 080412200eb448d07c7ccb312989ac27aa052738ff589e2f83973f909b506b450dc5c4e2
+      description: Hex encoded public key.
     cid:
       type: string
       example: baegaajaiaqjcahaxr4ry4styn74ronvr2nvfdmgxtrzyhsci2xqpw5eisrisrgn5

--- a/website/static/downloads/swagger.yaml
+++ b/website/static/downloads/swagger.yaml
@@ -653,7 +653,7 @@ paths:
               type: string
               example: 43
           required: false
-          description: Function parameters.
+          description: Function parameters, only numbers.
       responses:
         '200':
           description: Success
@@ -731,7 +731,7 @@ paths:
                     type: array
                     items:
                       type: string
-                      example: /SuperContracts/result.txt
+                      example: /SuperContracts/result.txt baegaajaiaqjcahaxr4ry4styn74ronvr2nvfdmgxtrzyhsci2xqpw5eisrisrgn5
         '400': 
           $ref: '#/components/responses/errorResp'
   /sc/executions:
@@ -895,6 +895,8 @@ components:
           properties:
             /:
               $ref: '#/components/schemas/cid'
+    pubKey:
+      $ref: '#/components/schemas/pubKey'
     cid:
       type: string
       example: baegaajaiaqjcahaxr4ry4styn74ronvr2nvfdmgxtrzyhsci2xqpw5eisrisrgn5
@@ -910,14 +912,12 @@ components:
         drive:
           $ref: '#/components/schemas/cid'
         owner:
-          type: string
-          example: 080412200eb448d07c7ccb312989ac27aa052738ff589e2f83973f909b506b450dc5c4e2
-          description: Hex encoded public key.
+          $ref: '#/components/schemas/pubKey'
         replicators:
           type: array
           description: Hex encoded public keys.
           items:
-            $ref: '#/components/schemas/cid'
+            $ref: '#/components/schemas/pubKey'
         root:
           $ref: '#/components/schemas/cid'
         created:
@@ -974,9 +974,7 @@ components:
       type: object
       properties:
         replicator:
-          type: string
-          description: Hex encoded public keys.
-          example: 0804122068f50e10e5b8be2b7e9ddb687a667d6e94dd55fe02b4aed8195f51f9a242558b
+          $ref: '#/components/schemas/pubKey'
         faultyBlocks:
           type: array
           items:

--- a/website/static/downloads/swagger.yaml
+++ b/website/static/downloads/swagger.yaml
@@ -918,15 +918,8 @@ components:
           description: Hex encoded public keys.
           items:
             $ref: '#/components/schemas/cid'
-            example:
-              [
-                0804122068f50e10e5b8be2b7e9ddb687a667d6e94dd55fe02b4aed8195f51f9a242558b,
-                0804122073472a2e9dcea5c2a36eb7f6a34a634010391ec89e883d67360db16f28b9443c,
-                08041220d03918e35573c66578b5a0eed723fe2a46208783e13498751d9315115ca06d4b
-              ]
         root:
           $ref: '#/components/schemas/cid'
-          example: QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn
         created:
           type: integer
           format: int64
@@ -987,7 +980,7 @@ components:
         faultyBlocks:
           type: array
           items:
-            $ref: '#/components/parameters/driveIdParam'
+            $ref: '#/components/schemas/cid'
     error:
       type: object
       properties:


### PR DESCRIPTION
Schema contained following errors causing generator to fail with errors
- $ref can not be used together with example. it is the referenced entity that provides example
- schema parameter can not be ref to query parameter it has to be reference to another schema